### PR TITLE
Bumps serials numbers on all three zones, and changes dns RR.

### DIFF
--- a/measurement-lab.org
+++ b/measurement-lab.org
@@ -8,7 +8,7 @@ $ORIGIN measurement-lab.org.
 $TTL    300
 
 @       IN      SOA     sns-pb.isc.org. support.measurementlab.net. (
-        2016112900      ; Serial
+        2017012302      ; Serial
         3600     ; Refresh
         600       ; Retry
         604800      ; Expire

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2016111700 ;Serial Number
+    2017012302 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -89,7 +89,7 @@ mirror       IN    A    104.196.171.114
 wiki         IN    A    165.117.251.86
 monitor      IN    A    23.228.128.89
 vpn          IN    A    23.228.128.90
-dns          IN    A    23.228.128.91
+dns          IN    A    104.196.50.66
 
 ks1d         IN    A    23.228.128.70
 ks           IN    TXT    "v=spf1 a -all"

--- a/measurementlab.org
+++ b/measurementlab.org
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.org.
 $TTL 600
 
 @	IN	SOA	ns.chambana.net.  support.measurementlab.net.	(
-	2016080300 ;Serial Number
+	2017012302 ;Serial Number
 	1h  ;refresh
 	900 ;retry
 	1w  ;expire


### PR DESCRIPTION
The old zone file repository, [salt-config-private](https://github.com/m-lab/salt-config-private/tree/master/salt/files/dns), was updated to point the existing DNS server to point to the new GCE-based DNS server. With that done we now need to update the serial numbers of all the zones plus the dns.measurementlab.net record in the new official zone repository (this repo). All the serial numbers should be higher than any of the ones in the old zones being served by the old server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/2)
<!-- Reviewable:end -->
