### PR TITLE
Add external IP for status-mlab-staging

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2017020200 ;Serial Number
+    2017040400 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -91,6 +91,7 @@ wiki         IN    A    165.117.251.86
 monitor      IN    A    23.228.128.89
 vpn          IN    A    23.228.128.90
 dns          IN    A    104.196.50.66
+status-mlab-staging IN    A    35.185.76.159
 
 ks1d         IN    A    23.228.128.70
 ks           IN    TXT    "v=spf1 a -all"

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -91,12 +91,15 @@ wiki         IN    A    165.117.251.86
 monitor      IN    A    23.228.128.89
 vpn          IN    A    23.228.128.90
 dns          IN    A    104.196.50.66
-status-mlab-staging IN    A    35.185.76.159
 
 ks1d         IN    A    23.228.128.70
 ks           IN    TXT    "v=spf1 a -all"
 ks._domainkey.ks    IN    TXT    "v=DKIM1\; k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqYy+nKUsFbI+7mw/eUandVL36luBfHTNdrH85QdKC7QpDV2syX+2Xe7TgnbJZA5NrveKeBzX47T0eM3agjBMDtEy8K4+SAyaMH69JxW9cJUC8tMUhvOCizWl2ySs+Kn3D63kyATXgSaZ2CK+cU4FbkxqEQpWz3tkpyAl1hextjwIDAQAB"
 ticket       IN    MX    10    ks.measurementlab.net.
+
+; allocated through GCP load balancer
+status-mlab-staging IN    A    35.185.76.159
+
 
 ; for compatibility with measurementlab.net web host
 localhost    IN    A    127.0.0.1


### PR DESCRIPTION
This adds the external IP for status-mlab-staging.measurementlab.net, verifiable here:
https://console.cloud.google.com/networking/loadbalancing/loadBalancers/list?project=mlab-staging
But I have my doubts about the format of this file. It looks like OA&M servers are listed under mlc. That seems out of date, but I think I've put this new entry with similar entries, so maybe it's ok?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/8)
<!-- Reviewable:end -->
