### PR TITLE
Add host record for status-mlab-oti

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -99,7 +99,7 @@ ticket       IN    MX    10    ks.measurementlab.net.
 
 ; allocated through GCP load balancer
 status-mlab-staging IN    A    35.185.76.159
-
+status-mlab-oti     IN    A    35.184.81.106
 
 ; for compatibility with measurementlab.net web host
 localhost    IN    A    127.0.0.1


### PR DESCRIPTION
This is in conjunction with the mlab-oti deployment of the prometheus-federation configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/11)
<!-- Reviewable:end -->
