### PR TITLE
incremented serial for measurementlab.net

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2017040400 ;Serial Number
+    2017052400 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire


### PR DESCRIPTION
This increments the serial for measurementlab.net zones, which was missed during the last code review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/13)
<!-- Reviewable:end -->
