### PR TITLE
Update the status-mlab-sandbox IP address.

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -98,7 +98,7 @@ ks._domainkey.ks    IN    TXT    "v=DKIM1\; k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4
 ticket       IN    MX    10    ks.measurementlab.net.
 
 ; allocated through GCP load balancer
-status-mlab-sandbox IN    A    104.196.164.214
+status-mlab-sandbox IN    A    35.184.166.181
 status-mlab-staging IN    A    35.185.76.159
 status-mlab-oti     IN    A    35.184.81.106
 


### PR DESCRIPTION
Some static IPs are bound to a GCP zone. This change updates the sandbox IP to use an IP in the us-central zone currently associated with the new mlab-sandbox/prometheus-federation cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/18)
<!-- Reviewable:end -->
