### PR TITLE
Adds a new zone file for the new internal domain mlab.fun.

### DIFF
--- a/mlab.fun
+++ b/mlab.fun
@@ -1,0 +1,27 @@
+$ORIGIN mlab.fun.
+$TTL 600
+
+@           IN  SOA         sns-pb.isc.org. support.measurementlab.net. (
+    2017080800 ;Serial Number
+    1h         ;refresh
+    900        ;retry
+    1w         ;expire
+    1h )       ;minimum
+
+@           IN  NS          sns-pb.isc.org.
+@           IN  NS          ns-mlab.greenhost.net.
+
+sandbox     IN  NS  21600   ns-cloud-b1.googledomains.com.
+            IN  NS  21600   ns-cloud-b2.googledomains.com.
+            IN  NS  21600   ns-cloud-b3.googledomains.com.
+            IN  NS  21600   ns-cloud-b4.googledomains.com.
+
+staging     IN  NS  21600   ns-cloud-b1.googledomains.com.
+            IN  NS  21600   ns-cloud-b2.googledomains.com.
+            IN  NS  21600   ns-cloud-b3.googledomains.com.
+            IN  NS  21600   ns-cloud-b4.googledomains.com.
+
+oti         IN  NS  21600   ns-cloud-a1.googledomains.com.
+            IN  NS  21600   ns-cloud-a2.googledomains.com.
+            IN  NS  21600   ns-cloud-a3.googledomains.com.
+            IN  NS  21600   ns-cloud-a4.googledomains.com.


### PR DESCRIPTION
The new domain mlab.fun is intended to be a short (and fun) internal domain for operations' use. The subdomains `sandbox`, `staging` and `oti` are delegated to Google namerservers, and will be managed by Google Cloud DNS.

Not only will this provide us with a short, interesting domain for internal use, but it will expose us to usage of Google Cloud DNS, which may be valuable down the line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/21)
<!-- Reviewable:end -->
