### PR TITLE
Changes IPv4 of mirror.measurementlab.net to that of the new mirror GCE VM.

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2017092101 ;Serial Number
+    2017101700 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -86,7 +86,7 @@ mlc2d        IN    A    23.228.128.69
 mlc2         IN    A    23.228.128.86
 
 boot-test2   IN    A    23.228.128.87
-mirror       IN    A    104.196.171.114
+mirror       IN    A    35.196.187.127
 wiki         IN    A    165.117.251.86
 monitor      IN    A    23.228.128.89
 vpn          IN    A    23.228.128.90


### PR DESCRIPTION
The new [GCE VM, named mirror-measurementlab-net](https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-d/instances/mirror-measurementlab-net?project=mlab-oti&graph=GCE_CPU&duration=PT1H), in the mlab-oti project is replacing the old one in the m-lab-yum-mirror project. This PR updates the IP address for `mirror` in the measurementlab.net zone file to point to this new VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/27)
<!-- Reviewable:end -->
