### PR TITLE
Removes old-style Prom/Grafana domain names from measurementlab.net zone

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -109,33 +109,18 @@ epoxy-test-1 IN    A    104.196.111.80
 ; Subdomains deleted to Google Cloud DNS
 ;
 ; Delegated to mlab-sandbox GCP project
-sandbox    21600    IN    NS    ns-cloud-e1.googledomains.com.
-           21600    IN    NS    ns-cloud-e2.googledomains.com.
-           21600    IN    NS    ns-cloud-e3.googledomains.com.
-           21600    IN    NS    ns-cloud-e4.googledomains.com.
-
 mlab-sandbox    21600    IN    NS    ns-cloud-e1.googledomains.com.
                 21600    IN    NS    ns-cloud-e2.googledomains.com.
                 21600    IN    NS    ns-cloud-e3.googledomains.com.
                 21600    IN    NS    ns-cloud-e4.googledomains.com.
 
 ; Delegated to mlab-staging GCP project
-staging    21600    IN    NS    ns-cloud-b1.googledomains.com.
-           21600    IN    NS    ns-cloud-b2.googledomains.com.
-           21600    IN    NS    ns-cloud-b3.googledomains.com.
-           21600    IN    NS    ns-cloud-b4.googledomains.com.
-
 mlab-staging    21600    IN    NS    ns-cloud-e1.googledomains.com.
                 21600    IN    NS    ns-cloud-e2.googledomains.com.
                 21600    IN    NS    ns-cloud-e3.googledomains.com.
                 21600    IN    NS    ns-cloud-e4.googledomains.com.
 
 ; Delegated to mlab-oti GCP project
-oti        21600    IN    NS    ns-cloud-e1.googledomains.com.
-           21600    IN    NS    ns-cloud-e2.googledomains.com.
-           21600    IN    NS    ns-cloud-e3.googledomains.com.
-           21600    IN    NS    ns-cloud-e4.googledomains.com.
-
 mlab-oti        21600    IN    NS    ns-cloud-d1.googledomains.com.
                 21600    IN    NS    ns-cloud-d2.googledomains.com.
                 21600    IN    NS    ns-cloud-d3.googledomains.com.

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -97,11 +97,6 @@ ks           IN    TXT    "v=spf1 a -all"
 ks._domainkey.ks    IN    TXT    "v=DKIM1\; k=rsa\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqYy+nKUsFbI+7mw/eUandVL36luBfHTNdrH85QdKC7QpDV2syX+2Xe7TgnbJZA5NrveKeBzX47T0eM3agjBMDtEy8K4+SAyaMH69JxW9cJUC8tMUhvOCizWl2ySs+Kn3D63kyATXgSaZ2CK+cU4FbkxqEQpWz3tkpyAl1hextjwIDAQAB"
 ticket       IN    MX    10    ks.measurementlab.net.
 
-; allocated through GCP load balancer
-status-mlab-sandbox IN    A    35.184.166.181
-status-mlab-staging IN    A    35.185.76.159
-status-mlab-oti     IN    A    35.184.81.106
-
 ; for compatibility with measurementlab.net web host
 localhost    IN    A    127.0.0.1
 

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2017102500 ;Serial Number
+    2017121900 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire


### PR DESCRIPTION
The old, original style Prom/Grafana domains were like "status-mlab-oti.measurementlab.net", the new ones are like "status.mlab-oti.measurementlab.net" and are managed by Google Cloud DNS. This PR removes the old-style ones to essentially force people to start using the new ones. Using the old ones will cause a login failure in Grafana anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/29)
<!-- Reviewable:end -->
