### PR TITLE
Add subdomain to test client device provisioning service

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -60,7 +60,7 @@ test         IN    CNAME    ghs.googlehosted.com.
 mirror-test  IN    CNAME    c.storage.googleapis.com.
 viz          IN    CNAME    ghs.googlehosted.com.
 data-api     IN    CNAME    ghs.googlehosted.com.
-openbalena      IN    A    35.209.108.67
+iot          IN    A        35.209.108.67
 
 ;
 ; mlc services

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2018100200 ;Serial Number
+    2018111000 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -60,7 +60,7 @@ test         IN    CNAME    ghs.googlehosted.com.
 mirror-test  IN    CNAME    c.storage.googleapis.com.
 viz          IN    CNAME    ghs.googlehosted.com.
 data-api     IN    CNAME    ghs.googlehosted.com.
-support      IN    A    35.208.161.188
+openbalena      IN    A    35.209.108.67
 
 ;
 ; mlc services


### PR DESCRIPTION
This PR removes the 'support' subdomain that was being tested and adds the 'iot' subdomain to test the openbalena client device provisioning server. @evfirerob could you review next week when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/31)
<!-- Reviewable:end -->
