### PR TITLE
add TXT and CNAME records to verify sandbox.measurementlab.net

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2018100200 ;Serial Number
+    2018111400 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -15,6 +15,7 @@ $TTL 120
 @        IN    TXT   "google-site-verification=lN4HHWmCV4gTtKslbFKZNrMNkYx4NhwsjSmmjsPr_Vg"
 @        IN    TXT   "google-site-verification=QzNQqgKdrElH34L_mzcEdeVoq1JP-WhiuMUB-Cm8oZg"
 @        IN    TXT   "google-site-verification=C901sQ7Uym2ZSuXbKSBsfncEXQ5tEzR4fAcAMoJnaX0"
+@        IN    TXT   "google-site-verification=7gl-zSB0HLZX0IO8Sdi1S8CEPj_7AY-IZODL0zWQ1OM"
 @        IN    MX    1    aspmx.l.google.com.
 @        IN    MX    5    alt1.aspmx.l.google.com.
 @        IN    MX    5    alt2.aspmx.l.google.com.
@@ -25,6 +26,7 @@ $TTL 120
 speed          IN    CNAME    d2617zhi55z8n7.cloudfront.net.
 www            IN    CNAME    d3f2vqxgk3exj.cloudfront.net.
 www-staging    IN    CNAME    ghs.googlehosted.com.
+sandbox        IN    CNAME    c.storage.googleapis.com
 
 ;@        IN    A     72.249.86.184
 ;www      IN    CNAME    measurementlab.net.


### PR DESCRIPTION
This PR adds TXT and CNAME records to verify the sandbox.measurementlab.net subdomain. This change is an initial part of testing hosting the website on GCS. See issue: https://github.com/m-lab/m-lab.github.io/issues/337

@evfirerob Could you take a look when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/32)
<!-- Reviewable:end -->
