### PR TITLE
redirect main website to GCS load balancer IP

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2018100200 ;Serial Number
+    2019012900 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -21,9 +21,9 @@ $TTL 120
 @        IN    MX    10    aspmx2.googlemail.com.
 @        IN    MX    10    aspmx3.googlemail.com.
 
-@              IN    A        45.56.98.222
+@              IN    A        35.241.9.189
+www            IN    A        35.241.9.189
 speed          IN    CNAME    d2617zhi55z8n7.cloudfront.net.
-www            IN    CNAME    d3f2vqxgk3exj.cloudfront.net.
 www-staging    IN    CNAME    ghs.googlehosted.com.
 
 ;@        IN    A     72.249.86.184
@@ -60,7 +60,6 @@ test         IN    CNAME    ghs.googlehosted.com.
 mirror-test  IN    CNAME    c.storage.googleapis.com.
 viz          IN    CNAME    ghs.googlehosted.com.
 data-api     IN    CNAME    ghs.googlehosted.com.
-support      IN    A    35.208.161.188
 
 ;
 ; mlc services

--- a/measurementlab.net
+++ b/measurementlab.net
@@ -21,7 +21,7 @@ $TTL 120
 @        IN    MX    10    aspmx2.googlemail.com.
 @        IN    MX    10    aspmx3.googlemail.com.
 
-@              IN    A        35.241.9.189
+@              IN    A        45.56.98.222
 www            IN    A        35.241.9.189
 speed          IN    CNAME    d2617zhi55z8n7.cloudfront.net.
 www-staging    IN    CNAME    ghs.googlehosted.com.


### PR DESCRIPTION
This PR redirects measurementlab.net and www.measurementlab.net to a new host IP, a GCS load balancer. Also removes one unused subdomain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/33)
<!-- Reviewable:end -->
