### PR TITLE
update IPs for speed.measurementlab.net to Firebase hosting IPs

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -3,7 +3,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2019020700 ;Serial Number
+    2019021500 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -26,7 +26,8 @@ $TTL 120
 @              IN    A        151.101.1.195
 www            IN    A        151.101.65.195
 www            IN    A        151.101.1.195
-speed          IN    CNAME    d2617zhi55z8n7.cloudfront.net.
+speed          IN    A        151.101.1.195
+speed          IN    A        151.101.65.195
 www-staging    IN    CNAME    ghs.googlehosted.com.
 
 ;@        IN    A     72.249.86.184


### PR DESCRIPTION
This PR completes the migration of the site, speed.measurementlab.net from AWS to Firebase. 

@nkinkade PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/35)
<!-- Reviewable:end -->
