### PR TITLE
Adds new NS record for ns.measurementlab.net to all zones

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -1,8 +1,8 @@
 $ORIGIN measurementlab.net.
 $TTL 120
 
-@    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2020012200 ;Serial Number
+@    IN    SOA    ns support.measurementlab.net.    (
+    2020012201 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -13,6 +13,7 @@ $TTL 120
 ;
 @            IN    NS    sns-pb.isc.org.
 @            IN    NS    ns-mlab.greenhost.net.
+@            IN    NS    ns
 
 ;
 ; MX records

--- a/measurementlab.org
+++ b/measurementlab.org
@@ -1,8 +1,8 @@
 $ORIGIN measurementlab.org.
 $TTL 120
 
-@    IN    SOA    sns-pb.isc.org.  support.measurementlab.net.    (
-    2019090400 ;Serial Number
+@    IN    SOA    ns.measurementlab.net.  support.measurementlab.net.    (
+    2020012200 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -13,6 +13,7 @@ $TTL 120
 ;
 @            IN    NS    sns-pb.isc.org.
 @            IN    NS    ns-mlab.greenhost.net.
+@            IN    NS    ns.measurementlab.net.
 
 ;
 ; A records


### PR DESCRIPTION
This new nameserver is also set at the "primary" nameserver in the SOA record.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/42)
<!-- Reviewable:end -->
