### PR TITLE
Removes NS records for sns-pb.isc.org.

### DIFF
--- a/measurementlab.net
+++ b/measurementlab.net
@@ -2,7 +2,7 @@ $ORIGIN measurementlab.net.
 $TTL 120
 
 @    IN    SOA    ns support.measurementlab.net.    (
-    2020012201 ;Serial Number
+    2020012700 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -11,7 +11,6 @@ $TTL 120
 ;
 ; NS records
 ;
-@            IN    NS    sns-pb.isc.org.
 @            IN    NS    ns-mlab.greenhost.net.
 @            IN    NS    ns
 

--- a/measurementlab.org
+++ b/measurementlab.org
@@ -2,7 +2,7 @@ $ORIGIN measurementlab.org.
 $TTL 120
 
 @    IN    SOA    ns.measurementlab.net.  support.measurementlab.net.    (
-    2020012200 ;Serial Number
+    2020012700 ;Serial Number
     1h  ;refresh
     900 ;retry
     1w  ;expire
@@ -11,7 +11,6 @@ $TTL 120
 ;
 ; NS records
 ;
-@            IN    NS    sns-pb.isc.org.
 @            IN    NS    ns-mlab.greenhost.net.
 @            IN    NS    ns.measurementlab.net.
 


### PR DESCRIPTION
The new configuration with ns.measurementlab.net seems to be working just fine, so we can now safely remove the ISC nameservers from the configs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/43)
<!-- Reviewable:end -->
