### PR TITLE
Deploy measurementlab.net zone to Cloud DNS

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+
+# Deploy the measurementlab.net zone to Cloud DNS.
+- name: gcr.io/cloud-builders/gcloud
+  entrypoint: '/bin/bash'
+  args: [
+    './deploy_dns.sh'
+  ]
+  env:
+  - 'PROJECT=${PROJECT_ID}'
+  - 'DOMAIN=measurementlab.net'
+

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
+#
+# A simple shell script to deploy a zone to Google Cloud DNS.
 
 set -eux
 
 _=${PROJECT:?Please provide PROJECT name in environment}
 _=${DOMAIN:?Please provide DOMAIN name in environment}
 
-# The maximum amount of time in seconds to wait for the zone file import
-# operation to complete before exiting with an error.
-MAX_IMPORT_WAIT="300"
-
 ZONE_FILE="/workspace/${DOMAIN}"
 
 # Remove the SOA record and any NS records.
-sed -i -e '/IN[[:space:]]\+SOA/,+5 d' \
+# TODO(kinkade): Once the measurementlab.net zone has been migrated to Cloud
+# DNS publicly, we can remove the SOA and NS records from the zone file and
+# remove this sed command.
+sed -i -e '/IN[[:space:]]\+SOA/,/^$/ d' \
        -e '/IN[[:space:]]\+NS/ d' \
        $ZONE_FILE
 

--- a/deploy_dns.sh
+++ b/deploy_dns.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eux
+
+_=${PROJECT:?Please provide PROJECT name in environment}
+_=${DOMAIN:?Please provide DOMAIN name in environment}
+
+# The maximum amount of time in seconds to wait for the zone file import
+# operation to complete before exiting with an error.
+MAX_IMPORT_WAIT="300"
+
+ZONE_FILE="/workspace/${DOMAIN}"
+
+# Remove the SOA record and any NS records.
+sed -i -e '/IN[[:space:]]\+SOA/,+5 d' \
+       -e '/IN[[:space:]]\+NS/ d' \
+       $ZONE_FILE
+
+# Deploy the zone to Cloud DNS
+gcloud dns record-sets import "${ZONE_FILE}" \
+    --zone-file-format \
+    --zone "${DOMAIN/./-}" \
+    --delete-all-existing \
+    --project "${PROJECT}"
+


### PR DESCRIPTION
This PR adds a simple shell script for deploying the measurementlab.net zone to Cloud DNS, and a basic Cloud Build config file, which calls this script. For now only measurementlab.net is deployed, but other zones could be easily added in the future.

These changes do not deploy the zone publicly. For anything to take effect publicly the glue records would need to be changed at the registrar. We can do that once we are comfortable with this process.

**NOTE**: Cloud Build in mlab-staging is not connected to this repo. You can only have the same (or overlapping) zone in each of the 5 Cloud DNS nameserver "shards". We already have the three project subdomains, plus this zone in mlab-oti and mlab-sandbox. This should allow a person to push changes to `sandbox-.*` and test their prereviewed changes on the sandbox Cloud DNS name servers. To send it to production requires a tag on the repo. That is, there is no staging for this zone... only sandbox -> production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/dns-zones/47)
<!-- Reviewable:end -->
